### PR TITLE
Fix for form failure repeat bug and scroll to top

### DIFF
--- a/client/components/journey/form.js
+++ b/client/components/journey/form.js
@@ -37,8 +37,7 @@ export default function Form({ action, followUp }) {
   /**
    * Compose the state used in this view.
    * First, we will use the global state methods found in the App Context.
-   * Then, we will create local state to manage the login journey. The
-   * underscore is an unused variable, since we don't need the current global state.
+   * Then, we will create local state to manage the login journey.
    *
    * The destructing of the hook's array results in index 0 having the state value,
    * and index 1 having the "setter" method to set new state values.
@@ -54,6 +53,7 @@ export default function Form({ action, followUp }) {
    * Component types
    * StepComponents are generic callback components that will be
    * generically rendered.
+   *
    * MessageComponent is intended for simply rendering messages to screen.
    * ErrorComponent is intended for displaying the error
    */
@@ -139,7 +139,7 @@ export default function Form({ action, followUp }) {
     }
 
     /**
-     * Iterate through callbacks mapping the callback to the
+     * Iterate through callbacks received from AM and map the callback to the
      * appropriate callback component, pushing that component
      * the StepComponent's array.
      */

--- a/client/components/journey/journey-state.js
+++ b/client/components/journey/journey-state.js
@@ -137,7 +137,10 @@ export default function useJourneyHandler({ action, form }) {
          ******************************************************************* */
         if (DEBUGGER) debugger;
         newStep.callbacks = previousCallbacks;
-        newStep.payload = previousPayload;
+        newStep.payload = {
+          ...previousPayload,
+          authId: newStep.payload.authId,
+        };
 
         setRenderStep(newStep);
         setSubmittingForm(false);

--- a/client/router.js
+++ b/client/router.js
@@ -8,8 +8,8 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import React from 'react';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { BrowserRouter, Switch, Route, useLocation } from 'react-router-dom';
 
 import { ProtectedRoute } from './utilities/route';
 import Todos from './views/todos';
@@ -19,6 +19,16 @@ import Home from './views/home';
 import Login from './views/login';
 import Logout from './views/logout';
 import Register from './views/register';
+
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
 
 /**
  * @function App - Application React view
@@ -43,6 +53,7 @@ export default function Router() {
           <Logout />
         </Route>
         <Route path="/">
+          <ScrollToTop />
           <Header />
           <Home />
           <Footer />


### PR DESCRIPTION
- Journey failures due to session timeout would only be fixed through refreshing the browser, but not recoverable otherwise. This fix ensures that the new authId is used; the old one was being used instead.
- Due to long registration pages, successful registration would redirect you to the home page, but not scrolled all the way to the top, which hid the top menu.